### PR TITLE
検索画面

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,8 +33,7 @@ const GlobalStyle = createGlobalStyle`
 
 const Display100vh = {
   overflow: "hidden",
-  backgounrdColor: "#F2F2F2",
-  backgroundImage: "radial-gradient(#9B9B9B 3%, transparent 3%)",
+  backgroundImage: "radial-gradient(#9B9B9B 3%, #F2F2F2 3%)",
   backgroundSize: "20px 20px",
   backgroundRepeat: "repeat",
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ const GlobalStyle = createGlobalStyle`
 
 const Display100vh = {
   overflow: "hidden",
+  backgounrdColor: "#F2F2F2",
   backgroundImage: "radial-gradient(#9B9B9B 3%, transparent 3%)",
   backgroundSize: "20px 20px",
   backgroundRepeat: "repeat",

--- a/src/components/atoms/ColorMemoThumb.tsx
+++ b/src/components/atoms/ColorMemoThumb.tsx
@@ -23,10 +23,11 @@ type Props = {
   memoId: number;
   content: MemoContent;
   deleteMode: boolean;
+  canEdit: boolean;
 };
 
 export const ColorMemoThumb: FC<Props> = (props) => {
-  const { memoId, content, deleteMode } = props;
+  const { memoId, content, deleteMode, canEdit } = props;
   return (
     <>
       {deleteMode ? (
@@ -39,7 +40,10 @@ export const ColorMemoThumb: FC<Props> = (props) => {
           </ColorCodeBox>
         </NoLinkWrapper>
       ) : (
-        <LinkWrapper to={`/memo/${memoId}`} state={content}>
+        <LinkWrapper
+          to={`/memo/${memoId}`}
+          state={{ state: content, editMode: canEdit }}
+        >
           <ColorCodeBox {...props}>
             <WhiteBox>
               <h2>{content.tagName}</h2>

--- a/src/components/atoms/ColorThumb.tsx
+++ b/src/components/atoms/ColorThumb.tsx
@@ -8,13 +8,17 @@ import { Font } from "../../style/Font";
 type Props = {
   memoId: number;
   content: MemoType;
+  canEdit: boolean;
 };
 
 export const ColorThumb: FC<Props> = (props) => {
-  const { memoId, content } = props;
+  const { memoId, content, canEdit } = props;
 
   return (
-    <StyledMemoWrapper to={`/memo/${memoId}`} state={content}>
+    <StyledMemoWrapper
+      to={`/memo/${memoId}`}
+      state={{ state: content, editMode: canEdit }}
+    >
       <StyledMemo bg={content.colorCode}># {content.colorCode}</StyledMemo>
     </StyledMemoWrapper>
   );

--- a/src/components/atoms/ColorThumb.tsx
+++ b/src/components/atoms/ColorThumb.tsx
@@ -39,6 +39,6 @@ const StyledMemo = styled.div<Props>`
   font-size: 16px;
   font-weight: ${regular};
   border-bottom-right-radius: 13px;
-  box-shadow: 0px 2px 3px 0px rgba(22, 22, 22, 0.15);
+  box-shadow: 0px 2px 3px 2px rgba(22, 22, 22, 0.15);
   box-sizing: border-box;
 `;

--- a/src/components/atoms/ColorThumb.tsx
+++ b/src/components/atoms/ColorThumb.tsx
@@ -1,20 +1,21 @@
 import { FC } from "react";
 import { Link } from "react-router-dom";
+import { MemoType } from "../../hooks/memos/useSearchMemos";
 import styled from "styled-components";
 import { ColorTheme } from "../../style/ColorTheme";
 import { Font } from "../../style/Font";
 
 type Props = {
   memoId: number;
-  colorCode: string;
+  content: MemoType;
 };
 
 export const ColorThumb: FC<Props> = (props) => {
-  const { memoId, colorCode } = props;
+  const { memoId, content } = props;
 
   return (
-    <StyledMemoWrapper to={`/memo/${memoId}`}>
-      <StyledMemo {...props}># {colorCode}</StyledMemo>
+    <StyledMemoWrapper to={`/memo/${memoId}`} state={content}>
+      <StyledMemo bg={content.colorCode}># {content.colorCode}</StyledMemo>
     </StyledMemoWrapper>
   );
 };
@@ -27,12 +28,12 @@ const StyledMemoWrapper = styled(Link)`
   display: inline-block;
   width: 165px;
 `;
-const StyledMemo = styled.div<Props>`
+const StyledMemo = styled.div<{ bg: string }>`
   display: flex;
   align-items: center;
   width: 100%;
   height: 60px;
-  background-color: ${(props) => `#${props.colorCode}`};
+  background-color: ${(props) => `#${props.bg}`};
   color: ${black};
   padding-left: 13px;
   font-family: ${Noto};

--- a/src/components/atoms/Icon/CommentIcon.tsx
+++ b/src/components/atoms/Icon/CommentIcon.tsx
@@ -2,11 +2,12 @@ import styled from "styled-components";
 
 type Props = {
   color: string;
+  onClick?: () => void;
 };
 
-export const CommentIcon = ({ color }: Props) => {
+export const CommentIcon = ({ color, onClick }: Props) => {
   return (
-    <Comment>
+    <Comment onClick={onClick}>
       <svg
         width="30"
         height="30"

--- a/src/components/atoms/Icon/LinkIcon.tsx
+++ b/src/components/atoms/Icon/LinkIcon.tsx
@@ -2,11 +2,12 @@ import styled from "styled-components";
 
 type Props = {
   color: string;
+  onClick?: () => void;
 };
 
-export const LinkIcon = ({ color }: Props) => {
+export const LinkIcon = ({ color, onClick }: Props) => {
   return (
-    <Link>
+    <Link onClick={onClick}>
       <svg
         width="25"
         height="25"

--- a/src/components/atoms/Icon/TrashIcon.tsx
+++ b/src/components/atoms/Icon/TrashIcon.tsx
@@ -2,13 +2,12 @@ import styled from "styled-components";
 
 type Props = {
   color: string;
+  onClick?: () => void;
 };
 
-export const TrashIcon = ({ color }: Props) => {
-  const onClick = () => {};
-
+export const TrashIcon = ({ color, onClick }: Props) => {
   return (
-    <Trash onClick={() => onClick()}>
+    <Trash onClick={onClick}>
       <svg
         width="30"
         height="30"

--- a/src/components/atoms/SearchForm.tsx
+++ b/src/components/atoms/SearchForm.tsx
@@ -1,27 +1,30 @@
-import { ChangeEvent, FC, useState } from "react";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { ColorTheme } from "../../style/ColorTheme";
 import { Font } from "../../style/Font";
 import search from "../../images/search.svg";
 
-export const SearchForm = () => {
-  let [text, setText] = useState<string>("");
+type Props = {
+  searchTag: string;
+  setSearchTag: Dispatch<SetStateAction<string>>;
+  setIsResult: Dispatch<SetStateAction<boolean>>;
+};
+
+export const SearchForm = ({ searchTag, setSearchTag, setIsResult }: Props) => {
+  const navigate = useNavigate();
   const onChangeText = (e: ChangeEvent<HTMLInputElement>) =>
-    setText(e.target.value);
+    setSearchTag(e.target.value);
 
   //Enterキー押した時の処理
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.nativeEvent.isComposing || e.key !== "Enter") {
       return;
     } else {
-      let firstText = text.slice(0, 1);
-      if (firstText === "#") {
-        //一文字目の#は削除する
-        text = text.slice(1);
-      }
-      window.location.href = `/search?tag=${text}`;
-      setText("");
+      if (searchTag.slice(0, 1) === "#") searchTag = searchTag.slice(1);
     }
+    navigate(`/search?tag=${searchTag}`);
+    setIsResult(true);
   };
 
   return (
@@ -31,7 +34,7 @@ export const SearchForm = () => {
       </SearchIcon>
       <SearchInputForm
         type="text"
-        value={text}
+        value={searchTag}
         onChange={onChangeText}
         placeholder="#名前やキーワードなど"
         onKeyDown={handleKeyDown}

--- a/src/components/organisms/ColorSetting.tsx
+++ b/src/components/organisms/ColorSetting.tsx
@@ -11,12 +11,12 @@ import styled from "styled-components";
 import { ColorTheme } from "../../style/ColorTheme";
 import { Font } from "../../style/Font";
 import "./ColorSetting.css";
-import { MemoContent } from "../../hooks/memos/usePostMemo";
+import { PostMemo } from "../../hooks/memos/usePostMemo";
 
 type Props = {
   setOpenedModal: Dispatch<SetStateAction<boolean>>;
   currentColor: string;
-  setNewMemo: Dispatch<SetStateAction<MemoContent>>;
+  setNewMemo: Dispatch<SetStateAction<PostMemo>>;
 };
 
 type ColorValues = {

--- a/src/components/organisms/MenuDrawer.tsx
+++ b/src/components/organisms/MenuDrawer.tsx
@@ -15,13 +15,13 @@ export const MenuDrawer = ({ isOpen, onClose }: Props) => {
       <DrawerOverlay />
       <DrawerContent style={DrawerStyle}>
         <MenuList>
-          <MenuListItems>
+          <MenuListItems onClick={onClose}>
             <Link to="/">メモ</Link>
           </MenuListItems>
-          <MenuListItems>
+          <MenuListItems onClick={onClose}>
             <Link to="/search">検索</Link>
           </MenuListItems>
-          <MenuListItems>
+          <MenuListItems onClick={onClose}>
             <Link to="/">アカウント</Link>
           </MenuListItems>
         </MenuList>

--- a/src/components/organisms/MenuDrawer.tsx
+++ b/src/components/organisms/MenuDrawer.tsx
@@ -19,7 +19,7 @@ export const MenuDrawer = ({ isOpen, onClose }: Props) => {
             <Link to="/">メモ</Link>
           </MenuListItems>
           <MenuListItems>
-            <Link to="/">検索</Link>
+            <Link to="/search">検索</Link>
           </MenuListItems>
           <MenuListItems>
             <Link to="/">アカウント</Link>
@@ -46,6 +46,7 @@ const MenuListItems = styled.li`
   font-weight: ${fontWeight.bold};
   font-family: ${fontFamily.Noto};
   font-size: 24px;
+  line-height: 1.45;
   color: ${palette.blueGreen};
 `;
 
@@ -54,7 +55,8 @@ const ContentLogout = styled(Link)`
   font-weight: ${fontWeight.bold};
   font-family: ${fontFamily.Noto};
   font-size: 20px;
-  color: ${palette.blueGreen};
+  line-height: 1.45;
+  color: ${palette.black};
 `;
 
 const DrawerStyle = {

--- a/src/components/organisms/SearchResult.tsx
+++ b/src/components/organisms/SearchResult.tsx
@@ -40,14 +40,14 @@ export const SearchResult: FC<Props> = (props) => {
           <TabPanel sx={TabPanelStyle}>
             {memosData.map((memo, index) => (
               <Wrapper key={index}>
-                <ColorThumb memoId={memo.id} content={memo} />
+                <ColorThumb memoId={memo.id} content={memo} canEdit={false} />
               </Wrapper>
             ))}
           </TabPanel>
           <TabPanel sx={TabPanelStyle}>
             {reversedData.map((memo, index) => (
               <Wrapper key={index}>
-                <ColorThumb memoId={memo.id} content={memo} />
+                <ColorThumb memoId={memo.id} content={memo} canEdit={false} />
               </Wrapper>
             ))}
           </TabPanel>

--- a/src/components/organisms/SearchResult.tsx
+++ b/src/components/organisms/SearchResult.tsx
@@ -40,14 +40,14 @@ export const SearchResult: FC<Props> = (props) => {
           <TabPanel sx={TabPanelStyle}>
             {memosData.map((memo, index) => (
               <Wrapper key={index}>
-                <ColorThumb memoId={memo.id} colorCode={memo.colorCode} />
+                <ColorThumb memoId={memo.id} content={memo} />
               </Wrapper>
             ))}
           </TabPanel>
           <TabPanel sx={TabPanelStyle}>
             {reversedData.map((memo, index) => (
               <Wrapper key={index}>
-                <ColorThumb memoId={memo.id} colorCode={memo.colorCode} />
+                <ColorThumb memoId={memo.id} content={memo} />
               </Wrapper>
             ))}
           </TabPanel>

--- a/src/components/organisms/SearchResult.tsx
+++ b/src/components/organisms/SearchResult.tsx
@@ -1,20 +1,10 @@
 import type { FC } from "react";
+import { useSearchMemos } from "../../hooks/memos/useSearchMemos";
 import { ColorThumb } from "../atoms/ColorThumb";
-import { useState, useEffect } from "react";
-import { MemoType } from "../../api/handler/memo/type";
-import { API_URL } from "../../api/endpoint";
 import styled from "styled-components";
 import { ColorTheme } from "../../style/ColorTheme";
 import { Font } from "../../style/Font";
-import {
-  Tabs,
-  TabList,
-  TabPanels,
-  Tab,
-  TabPanel,
-  Center,
-  Spinner,
-} from "@chakra-ui/react";
+import { Tabs, TabList, TabPanels, Tab, TabPanel } from "@chakra-ui/react";
 
 type Props = {
   tagName: string;
@@ -25,99 +15,39 @@ const { fontWeight, fontFamily } = Font;
 
 export const SearchResult: FC<Props> = (props) => {
   const { tagName } = props;
-
-  // -----カタログからロジックをそのまま持ってきた-----
-  const { data, error, loading } = useGetMemos(tagName);
-  if (error) {
-    return <p>error: {error.message}</p>;
-  }
-  if (loading) {
-    return (
-      <Center h="50vh">
-        <Spinner
-          thickness="4px"
-          speed="0.65s"
-          emptyColor="gray.200"
-          color="#00A8A6"
-          size="xl"
-        />
-      </Center>
-    );
-  }
-  // -------------------------------------------------
-
-  const reversedData = data.map((_, i, a) => a[a.length - 1 - i]);
+  const { memosData, memosLoading, memosError } = useSearchMemos(tagName);
+  const reversedData = memosData.map((_, i, a) => a[a.length - 1 - i]);
 
   return (
     <>
       <Tabs colorScheme="red" isFitted>
-        <TabList
-          position="fixed"
-          top="146px"
-          left="50%"
-          transform="translateX(-50%)"
-          width="319px"
-          border="none"
-          justifyContent="space-around"
-          fontSize="16px"
-          fontFamily={fontFamily.Noto}
-        >
+        <TabList sx={TabListStyle}>
           <Tab
-            color={palette.gray}
-            fontWeight={fontWeight.medium}
-            padding="0px"
-            _selected={{
-              color: "black",
-              borderColor: palette.gray,
-            }}
+            sx={TabStyle}
+            _selected={{ color: "black", borderColor: palette.gray }}
           >
             古い順
           </Tab>
           <Tab
-            color={palette.gray}
-            fontWeight={fontWeight.medium}
-            padding="0px"
-            _selected={{
-              color: "black",
-              borderColor: palette.gray,
-            }}
+            sx={TabStyle}
+            _selected={{ color: "black", borderColor: palette.gray }}
           >
             新しい順
           </Tab>
         </TabList>
 
-        <TabPanels>
-          <TabPanel
-            width="340px"
-            display="flex"
-            justifyContent="space-between"
-            flexWrap="wrap"
-            padding="0px"
-          >
-            {data.map((memo) => (
-              <Wrapper>
-                <ColorThumb
-                  key={memo.id}
-                  memoId={memo.id}
-                  colorCode={memo.colorCode}
-                />
+        <TabPanels sx={TabPanelsStyle}>
+          <TabPanel sx={TabPanelStyle}>
+            {memosData.map((memo, index) => (
+              <Wrapper key={index}>
+                <ColorThumb memoId={memo.id} colorCode={memo.colorCode} />
               </Wrapper>
             ))}
           </TabPanel>
-          <TabPanel
-            width="340px"
-            display="flex"
-            justifyContent="space-between"
-            flexWrap="wrap"
-            padding="0px"
-          >
-            {reversedData.map((memo) => (
-              <Wrapper>
-                <ColorThumb
-                  key={memo.id}
-                  memoId={memo.id}
-                  colorCode={memo.colorCode}
-                />
+          <TabPanel sx={TabPanelStyle}>
+            {reversedData.map((memo, index) => (
+              <Wrapper key={index}>
+                <ColorThumb memoId={memo.id} colorCode={memo.colorCode} />
               </Wrapper>
             ))}
           </TabPanel>
@@ -127,43 +57,39 @@ export const SearchResult: FC<Props> = (props) => {
   );
 };
 
-const useGetMemos = (tagName?: string) => {
-  const [state, setState] = useState<{
-    data: MemoType[];
-    loading: boolean;
-    error?: Error;
-  }>({
-    data: [],
-    loading: true,
-  });
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const url = tagName
-        ? `${API_URL}/memos/search?tag_name=${tagName}`
-        : `${API_URL}/memos/search`;
-
-      try {
-        await new Promise((resolve) => setTimeout(resolve, 1000)); // 挙動確認の為に sleep
-        const res = await fetch(url);
-        const data = await res.json();
-        setState({ data, loading: false });
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          const err = error;
-          setState((prev) => ({ ...prev, error: err, loading: false }));
-        }
-      }
-    };
-    fetchData();
-  }, []);
-
-  return state;
-};
-
 const Wrapper = styled.div`
   display: inline-block;
   &:nth-child(n + 3) {
     margin-top: 13px;
   }
 `;
+
+const TabListStyle = {
+  width: "340px",
+  border: "none",
+  justifyContent: "space-around",
+  fontSize: "16px",
+  fontFamily: `${fontFamily.Noto}`,
+};
+
+const TabStyle = {
+  color: `${palette.gray}`,
+  fontWeight: `${fontWeight.medium}`,
+  padding: "0px 0px 3px 0px",
+  lineHeight: 1.43,
+};
+
+const TabPanelStyle = {
+  width: "340px",
+  display: "flex",
+  justifyContent: "space-between",
+  flexWrap: "wrap",
+  padding: "0px",
+};
+
+const TabPanelsStyle = {
+  width: "340px",
+  height: "calc(100vh - 190px)",
+  overflowY: "scroll",
+  paddingTop: "15px",
+};

--- a/src/components/pages/MemoId.tsx
+++ b/src/components/pages/MemoId.tsx
@@ -7,7 +7,7 @@ type FileInfo = {
   name: string;
 };
 
-type MemoContent = {
+type MemoDisplay = {
   id: number;
   colorCode: string;
   tagName: string;
@@ -17,11 +17,17 @@ type MemoContent = {
   fileInfo: FileInfo;
 };
 
+type StateType = {
+  editMode: boolean;
+  state: MemoDisplay;
+};
+
 export const MemoId = () => {
   const location = useLocation();
-  const [memoContent, setMemoContent] = useState<MemoContent>(
-    location.state as MemoContent
+  const state = location.state as StateType;
+  const [memoContent, setMemoContent] = useState<MemoDisplay>(
+    state.state as MemoDisplay
   );
 
-  return <MemoLayout {...memoContent} />;
+  return <MemoLayout memoContent={memoContent} editMode={state.editMode} />;
 };

--- a/src/components/pages/Search.tsx
+++ b/src/components/pages/Search.tsx
@@ -1,26 +1,25 @@
-import type { FC } from "react";
-import { useSearchParams, Link } from "react-router-dom";
+import { FC, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { HeaderLayout } from "../templates/HeaderLayout";
 import { SearchLayout } from "../templates/SearchLayout";
-import { SearchResult } from "../organisms/SearchResult";
 
-type Props = {};
-
-export const Search: FC<Props> = (props) => {
+export const Search: FC = () => {
   const [searchParams] = useSearchParams();
   const tagName = searchParams.getAll("tag");
 
-  console.log("TagName=" + tagName);
-  console.log(tagName.length);
+  const [searchTag, setSearchTag] = useState<string>(tagName[0]);
+  const [isResult, setIsResult] = useState<boolean>(
+    tagName.length === 0 ? false : true
+  );
 
   return (
-    <>
-      {tagName.length == 0 ? (
-        <SearchLayout ttl="検索" isSearchResult={false}></SearchLayout>
-      ) : (
-        <SearchLayout ttl={"#" + tagName[0]} isSearchResult={true}>
-          <SearchResult tagName={tagName[0]} />
-        </SearchLayout>
-      )}
-    </>
+    <HeaderLayout>
+      <SearchLayout
+        isResult={isResult}
+        setIsResult={setIsResult}
+        searchTag={searchTag}
+        setSearchTag={setSearchTag}
+      />
+    </HeaderLayout>
   );
 };

--- a/src/components/templates/MemoLayout.tsx
+++ b/src/components/templates/MemoLayout.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { FC, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useHexToRgb } from "../../hooks/color/useHexToRgb";
 import { useCmykToRgb } from "../../hooks/color/useCmykToRgb";
@@ -21,7 +21,7 @@ type FileInfo = {
   name: string;
 };
 
-type MemoContent = {
+type MemoDisplay = {
   id: number;
   colorCode: string;
   tagName: string;
@@ -31,7 +31,13 @@ type MemoContent = {
   fileInfo: FileInfo;
 };
 
-export const MemoLayout = (memoContent: MemoContent) => {
+type Props = {
+  memoContent: MemoDisplay;
+  editMode: boolean;
+};
+
+export const MemoLayout: FC<Props> = (props) => {
+  const { memoContent, editMode } = props;
   const navigate = useNavigate();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isOpenLink, setIsOpenLink] = useState<boolean>(false);
@@ -56,7 +62,7 @@ export const MemoLayout = (memoContent: MemoContent) => {
       <Content>
         <Head>
           <ReturnArrow onClick={() => navigate(-1)} color={"white"} />
-          <EditButton onClick={handleClick} />
+          {editMode && <EditButton onClick={handleClick} />}
         </Head>
         <Main>
           <MemoInfo>
@@ -80,15 +86,11 @@ export const MemoLayout = (memoContent: MemoContent) => {
             </CodeListItem>
           </CodeList>
           <ActionIcons>
-            <button onClick={onOpen}>
-              <CommentIcon color={"white"} />
-            </button>
-            <button onClick={() => setIsOpenLink(true)}>
-              <LinkIcon color={"white"} />
-            </button>
-            <div onClick={() => setIsOpenTrash(true)}>
-              <TrashIcon color={"white"} />
-            </div>
+            <CommentIcon onClick={onOpen} color={"white"} />
+            <LinkIcon onClick={() => setIsOpenLink(true)} color={"white"} />
+            {editMode && (
+              <TrashIcon onClick={() => setIsOpenTrash(true)} color={"white"} />
+            )}
           </ActionIcons>
         </Main>
       </Content>

--- a/src/components/templates/MemosFileLayout.tsx
+++ b/src/components/templates/MemosFileLayout.tsx
@@ -44,6 +44,7 @@ export const MemosFileLayout = () => {
                   fileInfo: { id: memosData.id, name: memosData.name },
                 }}
                 deleteMode={false}
+                canEdit={true}
               />
             ))}
         </MemosWrap>

--- a/src/components/templates/SearchLayout.tsx
+++ b/src/components/templates/SearchLayout.tsx
@@ -1,36 +1,50 @@
-import type { FC, ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { FC, Dispatch, SetStateAction } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { Font } from "../../style/Font";
 import { ColorTheme } from "../../style/ColorTheme";
 import { SearchForm } from "../atoms/SearchForm";
+import { ReturnArrow } from "../atoms/Icon/ReturnArrow";
+import { SearchResult } from "../organisms/SearchResult";
 import shareIcon from "../../images/shareIcon.svg";
 import { TwitterShareButton, TwitterIcon } from "react-share";
 
 type Props = {
-  ttl: string;
-  children?: ReactNode;
-  isSearchResult: boolean;
+  isResult: boolean;
+  setIsResult: Dispatch<SetStateAction<boolean>>;
+  searchTag: string;
+  setSearchTag: Dispatch<SetStateAction<string>>;
 };
 
 export const SearchLayout: FC<Props> = (props) => {
-  const { ttl, children, isSearchResult } = props;
+  const { isResult, setIsResult, searchTag, setSearchTag } = props;
+  const navigate = useNavigate();
+
+  const onBack = () => {
+    setIsResult(false);
+    setSearchTag("");
+    navigate("/search");
+  };
 
   return (
     <>
-      <Display>
-        <ArrowIcon to="/search" isSearchResult={isSearchResult}></ArrowIcon>
-        <Container isSearchResult={isSearchResult}>
-          <h1>{ttl}</h1>
-          <TwitterShareButton url={"/"} title={"みんなも投稿してね！"}>
-            <img src={shareIcon} />
-          </TwitterShareButton>
-        </Container>
-        <FormWrapper isSearchResult={isSearchResult}>
-          <SearchForm />
-        </FormWrapper>
-      </Display>
-      <Overflow>{children}</Overflow>
+      <Content>
+        <Head>
+          {isResult && (
+            <ReturnArrow onClick={() => onBack()} color={"#161616"} />
+          )}
+        </Head>
+        <Title>{isResult ? `${searchTag}` : "検索"}</Title>
+        {!isResult ? (
+          <SearchForm
+            searchTag={searchTag}
+            setSearchTag={setSearchTag}
+            setIsResult={setIsResult}
+          />
+        ) : (
+          <SearchResult tagName={searchTag} />
+        )}
+      </Content>
     </>
   );
 };
@@ -38,40 +52,23 @@ export const SearchLayout: FC<Props> = (props) => {
 const { fontFamily, fontWeight } = Font;
 const { palette } = ColorTheme;
 
-const ArrowIcon = styled(Link)<{ isSearchResult: boolean }>`
-  display: ${(props) => (props.isSearchResult ? "block" : "none")};
-  position: fixed;
-  top: 43px;
-  margin-left: 11px;
-  width: 12px;
-  height: 12px;
-  border-bottom: 2.8px solid ${palette.black};
-  border-left: 2.8px solid ${palette.black};
-  transform: rotate(45deg);
+const Content = styled.div`
+  width: 340px;
+  margin: 35px auto 0;
 `;
 
-const Display = styled.div`
-  width: 340px;
-  margin: auto;
+const Head = styled.div`
+  height: 35px;
+  margin-bottom: 25px;
 `;
 
-const Container = styled.div<{ isSearchResult: boolean }>`
-  width: 340px;
-  position: fixed;
-  top: 95px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  h1 {
-    font-family: ${fontFamily.Noto};
-    font-weight: ${fontWeight.bold};
-    font-size: 24px;
-    color: ${palette.black};
-  }
-  img {
-    display: ${(props) => (props.isSearchResult ? "block" : "none")};
-    margin-right: 10px;
-  }
+const Title = styled.h1`
+  margin-bottom: 13px;
+  color: ${palette.black};
+  font-family: ${fontFamily.Noto};
+  font-size: 24px;
+  line-height: 1.45;
+  font-weight: ${fontWeight.bold};
 `;
 
 const FormWrapper = styled.div<{ isSearchResult: boolean }>`

--- a/src/hooks/memos/useSearchMemos.ts
+++ b/src/hooks/memos/useSearchMemos.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+import { client } from "../../lib/axios";
+
+type MemoType = {
+  id: number;
+  colorCode: string;
+  comment: string;
+  url: string;
+  tagName: string;
+  createdAt: string;
+};
+
+export const useSearchMemos = (tagName: string) => {
+  const [state, setState] = useState<{
+    memosData: MemoType[];
+    memosLoading: boolean;
+    memosError?: Error;
+  }>({
+    memosData: [],
+    memosLoading: true,
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      await client
+        .get(`search?q=${tagName}`)
+        .then((response) => {
+          setState({ memosData: response.data, memosLoading: false });
+        })
+        .catch((error) => console.log("メモ検索失敗..."));
+    };
+    fetchData();
+  }, []);
+
+  return state;
+};

--- a/src/hooks/memos/useSearchMemos.ts
+++ b/src/hooks/memos/useSearchMemos.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { client } from "../../lib/axios";
 
-type MemoType = {
+export type MemoType = {
   id: number;
   colorCode: string;
   comment: string;


### PR DESCRIPTION
## やったこと
- 検索画面前後のページ遷移の実装
- 検索結果→メモ詳細画面に進んだとき、編集ボタンや削除アイコンが非表示になるよう設定

### 目的

### 使い方

## やらないこと

## その他

#### 参考記事
