### PR TITLE
アカウント情報（ニックネームとcreatedID）の更新とサインアウト実装

### DIFF
--- a/src/components/organisms/AccountForms.tsx
+++ b/src/components/organisms/AccountForms.tsx
@@ -1,43 +1,54 @@
 import { useNavigate } from "react-router-dom";
 import { auth } from "../../FirebaseConfig";
 import { useLoginUser } from "../../hooks/useLoginUser";
-import { Stack } from "@chakra-ui/react";
+import { Stack, useDisclosure } from "@chakra-ui/react";
 import { SettingLink } from "../atoms/SettingLink";
 import { SettingButton } from "../atoms/Button/SettingButton";
+import { SignOutPopup } from "./Auth/SignOutPopup";
 
 export const AccountForms = () => {
   const user = auth.currentUser;
   const { loginUser } = useLoginUser();
   const navigate = useNavigate();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
-    <Stack spacing={"26px"}>
-      <Stack spacing={"14px"}>
-        <SettingLink label="ニックネーム" link="/setting/nickname">
-          {loginUser?.nickname}
-        </SettingLink>
-        <SettingLink label="ユーザー名" link="/setting/username">
-          @{loginUser?.createdID}
-        </SettingLink>
-        <SettingLink label="メール" link="/setting/mail">
-          {user?.email}
-        </SettingLink>
-        <SettingLink label="パスワード" link="/setting/password">
-          パスワードの変更
-        </SettingLink>
+    <>
+      <Stack spacing={"26px"}>
+        <Stack spacing={"14px"}>
+          <SettingLink label="ニックネーム" link="/setting/nickname">
+            {loginUser?.nickname}
+          </SettingLink>
+          <SettingLink label="ユーザー名" link="/setting/username">
+            @{loginUser?.createdID}
+          </SettingLink>
+          <SettingLink label="メール" link="/setting/mail">
+            {user?.email}
+          </SettingLink>
+          <SettingLink label="パスワード" link="/setting/password">
+            パスワードの変更
+          </SettingLink>
+        </Stack>
+        <Stack spacing={"14px"}>
+          <SettingButton
+            label="ログアウト"
+            onClick={() => onOpen()}
+            textcolor="#161616"
+          />
+          <SettingButton
+            label="アカウント削除"
+            onClick={() => navigate("/setting/deactivate")}
+            textcolor="#FD4A4A"
+          />
+        </Stack>
       </Stack>
-      <Stack spacing={"14px"}>
-        <SettingButton
-          label="ログアウト"
-          onClick={() => console.log("ログアウト")}
-          textcolor="#161616"
-        />
-        <SettingButton
-          label="アカウント削除"
-          onClick={() => navigate("/setting/deactivate")}
-          textcolor="#FD4A4A"
-        />
-      </Stack>
-    </Stack>
+      <SignOutPopup
+        isOpen={isOpen}
+        onClose={onClose}
+        onClick={() => console.log("ログアウト")}
+      >
+        ログアウトしますか？
+      </SignOutPopup>
+    </>
   );
 };

--- a/src/components/organisms/AccountForms.tsx
+++ b/src/components/organisms/AccountForms.tsx
@@ -1,7 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import { auth } from "../../FirebaseConfig";
 import { useLoginUser } from "../../hooks/useLoginUser";
-import { Stack, useDisclosure } from "@chakra-ui/react";
+import { useSignOut } from "../../hooks/account/useSignOut";
+import { useSignOutPopup } from "../../hooks/popup/useSignOutPopup";
+import { Stack } from "@chakra-ui/react";
 import { SettingLink } from "../atoms/SettingLink";
 import { SettingButton } from "../atoms/Button/SettingButton";
 import { SignOutPopup } from "./Auth/SignOutPopup";
@@ -10,7 +12,9 @@ export const AccountForms = () => {
   const user = auth.currentUser;
   const { loginUser } = useLoginUser();
   const navigate = useNavigate();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { SignOut } = useSignOut();
+  const { isOpenSignOut, onOpenSignOutPopup, onCloseSignOutPopup } =
+    useSignOutPopup();
 
   return (
     <>
@@ -32,7 +36,7 @@ export const AccountForms = () => {
         <Stack spacing={"14px"}>
           <SettingButton
             label="ログアウト"
-            onClick={() => onOpen()}
+            onClick={() => onOpenSignOutPopup()}
             textcolor="#161616"
           />
           <SettingButton
@@ -43,9 +47,9 @@ export const AccountForms = () => {
         </Stack>
       </Stack>
       <SignOutPopup
-        isOpen={isOpen}
-        onClose={onClose}
-        onClick={() => console.log("ログアウト")}
+        isOpen={isOpenSignOut}
+        onClose={onCloseSignOutPopup}
+        onClick={() => SignOut()}
       >
         ログアウトしますか？
       </SignOutPopup>

--- a/src/components/organisms/Auth/SignOutPopup.tsx
+++ b/src/components/organisms/Auth/SignOutPopup.tsx
@@ -1,0 +1,36 @@
+import { ReactNode, FC } from "react";
+import { Popup } from "../../molecules/Popup";
+import styled from "styled-components";
+import { ColorTheme } from "../../../style/ColorTheme";
+
+type Props = {
+  children: ReactNode;
+  subText?: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onClick: () => void;
+};
+
+export const SignOutPopup: FC<Props> = (props) => {
+  const { children, subText, isOpen, onClose, onClick } = props;
+  return (
+    <Popup
+      isOpen={isOpen}
+      onClose={onClose}
+      proposalText={`${children}`}
+      subtext={subText}
+    >
+      <SignOutButton onClick={onClick}>ログアウト</SignOutButton>
+    </Popup>
+  );
+};
+
+const { palette } = ColorTheme;
+
+const SignOutButton = styled.button`
+  width: 100%;
+  height: 40px;
+  display: grid;
+  place-content: center;
+  border-top: 1px solid ${palette.red};
+`;

--- a/src/components/organisms/MenuDrawer.tsx
+++ b/src/components/organisms/MenuDrawer.tsx
@@ -1,4 +1,7 @@
 import { Link } from "react-router-dom";
+import { useSignOut } from "../../hooks/account/useSignOut";
+import { useSignOutPopup } from "../../hooks/popup/useSignOutPopup";
+import { SignOutPopup } from "./Auth/SignOutPopup";
 import { Drawer, DrawerOverlay, DrawerContent } from "@chakra-ui/react";
 import styled from "styled-components";
 import { ColorTheme } from "../../style/ColorTheme";
@@ -10,24 +13,39 @@ type Props = {
 };
 
 export const MenuDrawer = ({ isOpen, onClose }: Props) => {
+  const { SignOut } = useSignOut();
+  const { isOpenSignOut, onOpenSignOutPopup, onCloseSignOutPopup } =
+    useSignOutPopup();
+
   return (
-    <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
-      <DrawerOverlay />
-      <DrawerContent style={DrawerStyle}>
-        <MenuList>
-          <MenuListItems onClick={onClose}>
-            <Link to="/">ファイル</Link>
-          </MenuListItems>
-          <MenuListItems onClick={onClose}>
-            <Link to="/search">検索</Link>
-          </MenuListItems>
-          <MenuListItems onClick={onClose}>
-            <Link to="/setting">アカウント</Link>
-          </MenuListItems>
-        </MenuList>
-        <ContentLogout to="/">ログアウト</ContentLogout>
-      </DrawerContent>
-    </Drawer>
+    <>
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
+        <DrawerOverlay />
+        <DrawerContent style={DrawerStyle}>
+          <MenuList>
+            <MenuListItems onClick={onClose}>
+              <Link to="/">ファイル</Link>
+            </MenuListItems>
+            <MenuListItems onClick={onClose}>
+              <Link to="/search">検索</Link>
+            </MenuListItems>
+            <MenuListItems onClick={onClose}>
+              <Link to="/setting">アカウント</Link>
+            </MenuListItems>
+          </MenuList>
+          <ContentLogout onClick={() => onOpenSignOutPopup()}>
+            ログアウト
+          </ContentLogout>
+        </DrawerContent>
+      </Drawer>
+      <SignOutPopup
+        isOpen={isOpenSignOut}
+        onClose={onCloseSignOutPopup}
+        onClick={() => SignOut()}
+      >
+        ログアウトしますか？
+      </SignOutPopup>
+    </>
   );
 };
 
@@ -50,7 +68,7 @@ const MenuListItems = styled.li`
   color: ${palette.blueGreen};
 `;
 
-const ContentLogout = styled(Link)`
+const ContentLogout = styled.h3`
   margin-top: 39px;
   font-weight: ${fontWeight.bold};
   font-family: ${fontFamily.Noto};

--- a/src/components/pages/account/SettingId.tsx
+++ b/src/components/pages/account/SettingId.tsx
@@ -1,10 +1,17 @@
 import type { FC } from "react";
+import { usePutAccount } from "../../../hooks/account/usePutAccount";
 import { SettingFeatureLayout } from "../../templates/SettingFeatureLayout";
 import { useLoginUser } from "../../../hooks/useLoginUser";
 
 export const SettingId: FC = () => {
   const { loginUser } = useLoginUser();
+  const { SendPutCreatedId } = usePutAccount();
+
   return (
-    <SettingFeatureLayout title={"ユーザー名"} data={loginUser?.createdID} />
+    <SettingFeatureLayout
+      title={"ユーザー名"}
+      data={loginUser?.createdID}
+      onClick={SendPutCreatedId}
+    />
   );
 };

--- a/src/components/pages/account/SettingMail.tsx
+++ b/src/components/pages/account/SettingMail.tsx
@@ -1,8 +1,17 @@
 import type { FC } from "react";
 import { auth } from "../../../FirebaseConfig";
+import { usePutAccount } from "../../../hooks/account/usePutAccount";
 import { SettingFeatureLayout } from "../../templates/SettingFeatureLayout";
 
 export const SettingMail: FC = () => {
   const user = auth.currentUser;
-  return <SettingFeatureLayout title={"メールアドレス"} data={user?.email} />;
+  const { SendPutMail } = usePutAccount();
+
+  return (
+    <SettingFeatureLayout
+      title={"メールアドレス"}
+      data={user?.email}
+      onClick={SendPutMail}
+    />
+  );
 };

--- a/src/components/pages/account/SettingName.tsx
+++ b/src/components/pages/account/SettingName.tsx
@@ -1,10 +1,17 @@
 import type { FC } from "react";
-import { SettingFeatureLayout } from "../../templates/SettingFeatureLayout";
 import { useLoginUser } from "../../../hooks/useLoginUser";
+import { usePutAccount } from "../../../hooks/account/usePutAccount";
+import { SettingFeatureLayout } from "../../templates/SettingFeatureLayout";
 
 export const SettingName: FC = () => {
   const { loginUser } = useLoginUser();
+  const { SendPutNickName } = usePutAccount();
+
   return (
-    <SettingFeatureLayout title={"ニックネーム"} data={loginUser?.nickname} />
+    <SettingFeatureLayout
+      title={"ニックネーム"}
+      data={loginUser?.nickname}
+      onClick={SendPutNickName}
+    />
   );
 };

--- a/src/components/templates/SettingFeatureLayout.tsx
+++ b/src/components/templates/SettingFeatureLayout.tsx
@@ -10,9 +10,10 @@ import { FormDelete } from "../atoms/Icon/FormDelete";
 type Props = {
   title: string;
   data: string | null | undefined;
+  onClick: (newData: string) => void;
 };
 
-export const SettingFeatureLayout = ({ title, data }: Props) => {
+export const SettingFeatureLayout = ({ title, data, onClick }: Props) => {
   const navigate = useNavigate();
   const [value, setValue] = useState<string>("");
 
@@ -33,7 +34,7 @@ export const SettingFeatureLayout = ({ title, data }: Props) => {
       <Head>
         <ReturnArrow onClick={() => navigate("/setting")} color={"#161616"} />
         <SettingTitle>{title}</SettingTitle>
-        <CompleteButton>完了</CompleteButton>
+        <CompleteButton onClick={() => onClick(value)}>完了</CompleteButton>
       </Head>
       <InputArea>
         <InputGroup sx={{ width: "340px" }}>

--- a/src/hooks/account/usePutAccount.ts
+++ b/src/hooks/account/usePutAccount.ts
@@ -1,0 +1,41 @@
+import { useNavigate } from "react-router-dom";
+import { useLoginUser } from "../useLoginUser";
+import { client } from "../../lib/axios";
+
+export const usePutAccount = () => {
+  const navigate = useNavigate();
+  const { loginUser, setLoginUser } = useLoginUser();
+
+  const SendPutNickName = async (newData: string) => {
+    const sendData = {
+      nickname: newData,
+    };
+    console.log(sendData);
+    await client.put("settings_account", sendData).then((res) => {
+      navigate("/setting", { state: res.status });
+      console.log(loginUser);
+    });
+  };
+
+  const SendPutCreatedId = async (newData: string) => {
+    const sendData = {
+      createdID: newData,
+    };
+    console.log(sendData);
+    await client.put("settings_account", sendData).then(() => {
+      navigate("/setting");
+    });
+  };
+
+  const SendPutMail = async (newData: string) => {
+    const sendData = {
+      email: newData,
+    };
+    console.log(sendData);
+    await client.put("settings_authAccount", sendData).then(() => {
+      navigate("/setting");
+    });
+  };
+
+  return { SendPutNickName, SendPutCreatedId, SendPutMail };
+};

--- a/src/hooks/account/usePutAccount.ts
+++ b/src/hooks/account/usePutAccount.ts
@@ -10,10 +10,9 @@ export const usePutAccount = () => {
     const sendData = {
       nickname: newData,
     };
-    console.log(sendData);
     await client.put("settings_account", sendData).then((res) => {
       navigate("/setting", { state: res.status });
-      console.log(loginUser);
+      setLoginUser({ ...res.data, isAdmin: true });
     });
   };
 
@@ -21,9 +20,9 @@ export const usePutAccount = () => {
     const sendData = {
       createdID: newData,
     };
-    console.log(sendData);
-    await client.put("settings_account", sendData).then(() => {
-      navigate("/setting");
+    await client.put("settings_account", sendData).then((res) => {
+      navigate("/setting", { state: res.status });
+      setLoginUser({ ...res.data, isAdmin: true });
     });
   };
 
@@ -32,7 +31,8 @@ export const usePutAccount = () => {
       email: newData,
     };
     console.log(sendData);
-    await client.put("settings_authAccount", sendData).then(() => {
+    await client.put("settings_authAccount", sendData).then((res) => {
+      console.log(res);
       navigate("/setting");
     });
   };

--- a/src/hooks/account/useSignOut.ts
+++ b/src/hooks/account/useSignOut.ts
@@ -1,0 +1,17 @@
+import { useNavigate } from "react-router-dom";
+import { auth } from "../../FirebaseConfig";
+import { useLoginUser } from "../useLoginUser";
+
+export const useSignOut = () => {
+  const navigate = useNavigate();
+  const { setLoginUser } = useLoginUser();
+
+  const SignOut = async () => {
+    auth.signOut().then(() => {
+      setLoginUser(null);
+      navigate("/login");
+    });
+  };
+
+  return { SignOut };
+};

--- a/src/hooks/popup/useSignOutPopup.ts
+++ b/src/hooks/popup/useSignOutPopup.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export const useSignOutPopup = () => {
+  const [isOpenSignOut, setIsOpenSignOut] = useState<boolean>(false);
+
+  const onOpenSignOutPopup = () => setIsOpenSignOut(true);
+  const onCloseSignOutPopup = () => setIsOpenSignOut(false);
+
+  return {
+    isOpenSignOut,
+    setIsOpenSignOut,
+    onOpenSignOutPopup,
+    onCloseSignOutPopup,
+  };
+};

--- a/src/providers/LoginUserProvider.tsx
+++ b/src/providers/LoginUserProvider.tsx
@@ -3,12 +3,8 @@ import {
   Dispatch,
   ReactNode,
   SetStateAction,
-  useEffect,
   useState,
 } from "react";
-import { auth } from "../FirebaseConfig";
-import { client } from "../lib/axios";
-import { Loading } from "../components/pages/Loading";
 
 type User = {
   id: number;
@@ -31,26 +27,11 @@ const LoginUserProvider = (props: { children: ReactNode }) => {
   const { children } = props;
   const [loginUser, setLoginUser] = useState<LoginUser | null>(null);
 
-  useEffect(() => {
-    auth.onAuthStateChanged((user) => {
-      if (user) {
-        client.get("login").then((response) => {
-          const isAdmin = true;
-          setLoginUser({ ...response.data, isAdmin });
-        });
-      }
-    });
-  }, []);
-
-  if (loginUser?.isAdmin) {
-    return (
-      <LoginUserContext.Provider value={{ loginUser, setLoginUser }}>
-        {children}
-      </LoginUserContext.Provider>
-    );
-  } else {
-    return <Loading />;
-  }
+  return (
+    <LoginUserContext.Provider value={{ loginUser, setLoginUser }}>
+      {children}
+    </LoginUserContext.Provider>
+  );
 };
 
 export { LoginUserContext, LoginUserProvider };

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,17 +1,30 @@
-import { FC } from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import { FC, useEffect } from "react";
+import { useNavigate, Outlet } from "react-router-dom";
+import { auth } from "../FirebaseConfig";
+import { client } from "../lib/axios";
 import { useLoginUser } from "../hooks/useLoginUser";
+import { Loading } from "../components/pages/Loading";
 
 export const ProtectedRoute: FC = () => {
-  const { loginUser } = useLoginUser();
+  const { loginUser, setLoginUser } = useLoginUser();
+  const navigate = useNavigate();
 
-  if (!loginUser?.isAdmin) {
-    return <Navigate to="/login" />;
+  useEffect(() => {
+    auth.onAuthStateChanged((user) => {
+      if (user) {
+        client.get("login").then((response) => {
+          const isAdmin = true;
+          setLoginUser({ ...response.data, isAdmin });
+        });
+      } else {
+        navigate("/login");
+      }
+    });
+  }, []);
+
+  if (loginUser?.isAdmin) {
+    return <Outlet />;
+  } else {
+    return <Loading />;
   }
-
-  return (
-    <>
-      <Outlet />
-    </>
-  );
 };


### PR DESCRIPTION
## やったこと
- ニックネームとcreatedIDを更新するフックの作成
- サインアウト実装

## 詰まったこと
- メールアドレスを更新すると、Firebase console上のデータは更新されるけど `getAuth().currentUser`で取得するデータが更新前のものになってしまう+リロード時にログインしているユーザーがいない扱いになってしまう
→メアド更新の際もpwが必要っぽい…？